### PR TITLE
Function translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ export default App;
 
 The `translations` object can have objects inside of it. For example:
 
-```
+```javascript
 const translations = {
   en: {
     home: {
@@ -203,8 +203,29 @@ const translations = {
 
 These can be used by giving the `I18n` component `t="home.title"`:
 
-```
+```jsx
 <I18n t="home.title" />
+```
+
+##### Function translations
+
+The `translations` object can have a function as the translation. For example:
+
+```javascript
+const translations = {
+  en: {
+    time: ({ hour, minute }) => `${hour}:${minute}`,
+  },
+  fr: {
+    time: ({ hour, minute }) => `${hour}h${minute}`
+  },
+};
+```
+
+An argument can be passed to the function by giving the `I18n` component `args`:
+
+```jsx
+<I18n t="time" args={{ hour: '12', minute: '30' }}  />
 ```
 
 ##### Default translation

--- a/src/lib/components/I18n/__snapshots__/createI18n.test.js.snap
+++ b/src/lib/components/I18n/__snapshots__/createI18n.test.js.snap
@@ -8,6 +8,8 @@ exports[`default translations uses the default if one is given and there is no t
 
 exports[`default translations uses the default language translation when there is none 1`] = `"Home"`;
 
+exports[`function translations executes the function and uses the result as the translation 1`] = `"12:30"`;
+
 exports[`nested translations shows a nested translation 1`] = `"Nested"`;
 
 exports[`renders without crashing 1`] = `"Home"`;

--- a/src/lib/components/I18n/createI18n.test.js
+++ b/src/lib/components/I18n/createI18n.test.js
@@ -66,6 +66,27 @@ describe('nested translations', () => {
   });
 });
 
+describe('function translations', () => {
+  beforeAll(() => {
+    translations = {
+      en: {
+        time: ({ hour, minute }) => `${hour}:${minute}`,
+      },
+    };
+  });
+
+  it('executes the function and uses the result as the translation', () => {
+    const component = (
+      <MemoryRouter>
+        <I18n t="time" args={{ hour: '12', minute: '30' }} />
+      </MemoryRouter>
+    );
+
+    const tree = renderer.create(component).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});
+
 describe('default translations', () => {
   beforeAll(() => {
     translations = {


### PR DESCRIPTION
Allow function translations. For example:

```javascript
const translations = {
  en: {
    time: ({ hour, minute }) => `${hour}:${minute}`,
  },
  fr: {
    time: ({ hour, minute }) => `${hour}h${minute}`
  },
};
```

```jsx
<I18n t="time" args={{ hour: '12', minute: '30' }}  />
```