### PR TITLE
Accept object or function for to

### DIFF
--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -29,12 +29,12 @@ const Header = ({
       </NavLink>
     </li>
     <li>
-      <NavLink to="/about">
+      <NavLink to={{ pathname: '/about' }}>
         <I18n t="about" />
       </NavLink>
     </li>
     <li>
-      <NavLink to="/topics">
+      <NavLink to={(location) => ({ ...location, pathname: '/topics' })}>
         <I18n t="topics" />
       </NavLink>
     </li>

--- a/src/lib/components/I18n/withLocale.js
+++ b/src/lib/components/I18n/withLocale.js
@@ -3,6 +3,47 @@ import PropTypes from 'prop-types';
 
 import { withRouter } from 'react-router-dom';
 
+const newToPath = (to, locale) => (
+  to[0] === '/'
+    ? `/${locale}${to}`
+    : `${locale}/${to}`
+);
+
+const newToObject = (to, locale) => {
+  const { pathname } = to;
+
+  if (typeof pathname !== 'string') { return to; }
+
+  const toObj = { ...to, pathname: newToPath(pathname, locale) };
+
+  return toObj;
+};
+
+const newToFunction = (to, locale) => (
+  (location) => {
+    const result = to(location);
+
+    return typeof result === 'string'
+      ? newToPath(result, locale)
+      : newToObject(result, locale);
+  }
+);
+
+const newTo = (to, params) => {
+  if (!params) { return to; }
+
+  const { locale } = params;
+
+  if (!locale) { return to; }
+
+  const type = typeof to;
+
+  if (type === 'string') { return newToPath(to, locale); }
+  if (type === 'function') { return newToFunction(to, locale); }
+
+  return newToObject(to, locale);
+};
+
 const withLocale = (WrappedComponent) => {
   const NewComponent = ({
     to,
@@ -24,24 +65,21 @@ const withLocale = (WrappedComponent) => {
       );
     }
 
-    let path = to;
-
-    if (params && params.locale) {
-      path = path[0] === '/'
-        ? `/${params.locale}${path}`
-        : `${params.locale}/${path}`;
-    }
-
     return (
       <WrappedComponent
-        to={path}
+        to={newTo(to, params)}
         {...rest}
       />
     );
   };
 
   NewComponent.propTypes = {
-    to: PropTypes.string.isRequired,
+    to: PropTypes.oneOfType([
+      PropTypes.string,
+      // eslint-disable-next-line react/forbid-prop-types
+      PropTypes.object,
+      PropTypes.func,
+    ]).isRequired,
     match: PropTypes.shape({
       params: PropTypes.shape({
         locale: PropTypes.string,


### PR DESCRIPTION
Fixes https://github.com/perseids-tools/react-router-i18n/issues/25

In the `<Link>`, `<NavLink>`, and `<Redirect>` components, accept a string, object, or function for `to`. Previously, only a string was accepted.